### PR TITLE
Use uv to pull dependencies

### DIFF
--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'wpilibsuite' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Merge

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'wpilibsuite/frc-docs-translations'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: 'true'
@@ -24,18 +24,11 @@ jobs:
         run: |
           curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash -s -- v1.6.7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-          cache: 'pip'
-          cache-dependency-path: 'requirements.txt'
-      - name: Update wheel
-        run: |
-          pip install wheel==0.34.2
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r ./requirements.txt
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
       - name: Update Translations
         run: |
           bash -l scripts/update.sh

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -26,9 +26,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Update Translations
         run: |
           bash -l scripts/update.sh

--- a/.gitignore
+++ b/.gitignore
@@ -94,5 +94,6 @@ $RECYCLE.BIN/
 
 # Python
 *.pyc
+.venv/
 
 locale/pot

--- a/README.md
+++ b/README.md
@@ -9,19 +9,15 @@ Please visit the translation guide [here](https://docs.wpilib.org/en/latest/docs
 
 ## Building Locally
 
-**Please note:** Python 3.6 or higher is required to build this documentation
+First, install the frc-docs build prerequisites listed [here](https://docs.wpilib.org/en/stable/docs/contributing/frc-docs/build-instructions.html#prerequisites).
 
-First, clone this repo using the follwowing command
+Clone this repo using the following command:
 
 - ``git clone --recurse-submodules https://github.com/wpilibsuite/frc-docs-translations.git``
 
-and ensure that all requirements are up-to-date by running
+Translated documents can be built by running
 
-- ``pip install -r frc-docs/source/requirements.txt``
-
-Translated documents can be built by running 
-
-- ``sphinx-build -D language=LANG -b html . _build/html``
+- ``uv run --project frc-docs sphinx-build -D language=LANG -b html . _build/html``
 
 where ``LANG`` is the locale code of your language. You can view a list of supported locales, by checking the ``locale`` directory.
 
@@ -51,10 +47,12 @@ This will bring up a screen containing your API key. Write this down and save it
 
 ### Pulling from Transifex
 
+Install the Transifex CLI following the [installation instructions](https://developers.transifex.com/docs/cli#installation) for your operating system.
+
 The first step is to generate all translatable files from Sphinx. This can be done with the ``gettext`` builder. Type the below command to generate translatable POT files.
 
 ```
-sphinx-build -T -b gettext frc-docs/source locale/pot
+uv run --project frc-docs sphinx-build -T -b gettext frc-docs/source locale/pot
 ```
 
 Go ahead and run the below command to save your transifex token to the python transifex client.
@@ -68,7 +66,7 @@ This will bring up a prompt where you can paste in your API token.
 Now we need to grab a list of currently used resources (and their slugs) to grab from transifex. Go ahead and run the command below to do that.
 
 ```
-sphinx-intl update-txconfig-resources -p locale/pot -d locale --transifex-project-name frc-docs
+uvx sphinx-intl update-txconfig-resources -p locale/pot -d locale --transifex-project-name frc-docs
 ```
 
 In the translation project directory, the below command can be used to grab all reviewed French (Canada) translations.

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,19 +6,24 @@ sphinx:
   fail_on_warning: false
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.13"
   apt_packages:
     - librsvg2-bin
- 
+  jobs:
+    pre_create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    create_environment:
+      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    install:
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --project frc-docs
+
 formats:
   - htmlzip
   - pdf
 
-python:
-  install:
-  - requirements: requirements.txt
-  
 submodules:
   include: all

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
--r frc-docs/source/requirements.txt
-sphinx-intl==2.3.2 \
-    --hash=sha256:f0082f9383066bab8406129a2ed531d21c38706d08467bf5ca3714e8914bb2be

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -12,13 +12,13 @@ ORGANIZATION=wpilib
 cd `dirname $0`/..
 
 # Create POT Files
-sphinx-build -T -b gettext $MAINPROJECT/source locale/pot
+uv run --project frc-docs sphinx-build -T -b gettext $MAINPROJECT/source locale/pot
 
 # Update .tx/config
 rm .tx/config
-sphinx-intl create-txconfig
+uvx sphinx-intl create-txconfig
 echo "lang_map = ${LANG_MAP}" >> .tx/config
-sphinx-intl update-txconfig-resources -p locale/pot -d locale --transifex-project-name $MAINPROJECT --transifex-organization-name $ORGANIZATION
+uvx sphinx-intl update-txconfig-resources -p locale/pot -d locale --transifex-project-name $MAINPROJECT --transifex-organization-name $ORGANIZATION
 
 # Push and pull from Transifex. It is important to push then pull!
 # If you pull then push, the PO files will contain out of date strings.


### PR DESCRIPTION
This repo won't have it's own pyproject.toml and lockfile, it will use frc-docs'. sphinx-intl is just being used as a cli tool so we can run it with uvx.

I tested the build commands and the update script (minus push/pull) locally.